### PR TITLE
Use ruboty even more than 1.1.3

### DIFF
--- a/ruboty-rss.gemspec
+++ b/ruboty-rss.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency "ruboty", "~> 1.0.2"
+  spec.add_dependency "ruboty", "~> 1.1.3"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Found following error in Ruby 2.1 and 2.2:

``` console
$ bundle exec ruboty
/Users/hfm/program/exam-ruboty-rss/vendor/bundle/ruby/2.2.0/gems/ruboty-1.0.4/lib/ruboty/command_builder.rb:22:in `options': undefined method `parse!' for Slop:Module (NoMethodError)
        from /Users/hfm/program/exam-ruboty-rss/vendor/bundle/ruby/2.2.0/gems/mem-0.1.5/lib/mem.rb:44:in `block in memoize'
        from /Users/hfm/program/exam-ruboty-rss/vendor/bundle/ruby/2.2.0/gems/ruboty-1.0.4/lib/ruboty/command_builder.rb:18:in `command_class'
        from /Users/hfm/program/exam-ruboty-rss/vendor/bundle/ruby/2.2.0/gems/ruboty-1.0.4/lib/ruboty/command_builder.rb:12:in `build'
        from /Users/hfm/program/exam-ruboty-rss/vendor/bundle/ruby/2.2.0/gems/ruboty-1.0.4/bin/ruboty:6:in `<top (required)>'
        from /Users/hfm/program/exam-ruboty-rss/vendor/bundle/ruby/2.2.0/bin/ruboty:23:in `load'
        from /Users/hfm/program/exam-ruboty-rss/vendor/bundle/ruby/2.2.0/bin/ruboty:23:in `<main>'
```

Ruboty more than v1.1.3 solves this error:
- Error with slop 4.0.0 https://github.com/r7kamura/ruboty/issues/9
